### PR TITLE
Enable user registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ is available at `/api/index.html`. Start the application and navigate to
 
 Authentication is performed via:
 
+* `POST /api/auth/register` – create a new user account.
 * `POST /api/auth/login` &ndash; authenticate with an administrator username and password. The response contains a JWT token.
 
 Include this token in the `Authorization` header using the `Bearer` scheme when calling secured `/api` endpoints.

--- a/src/main/java/com/example/library/config/SecurityConfig.java
+++ b/src/main/java/com/example/library/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
                 .requestMatchers(
                         "/", "/index.html",
                         "/app.js", "/styles.css", "/theme.js",
-                        "/auth/login", "/auth/session",
+                        "/auth/register", "/auth/login", "/auth/session",
                         "/swagger-ui.html", "/v3/api-docs/**", "/swagger-ui/**"
                 ).permitAll()
                 .anyRequest().authenticated()


### PR DESCRIPTION
## Summary
- allow unauthenticated access to `/auth/register`
- document registration endpoint in README

## Testing
- `./mvnw -q test` *(fails: unable to download Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_685d9b4390d8832fa766d743bae8ef6d