### PR TITLE
Fix registration path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ java -jar target/Lista5-0.0.1-SNAPSHOT.jar
 
 The application exposes CRUD endpoints under `/api`. Admins can manage books under `/api/books`, authors under `/api/authors`, users under `/api/users` and loans under `/api/loans`.
 
-Swagger UI is available once the application is running at `http://localhost:8080/swagger-ui.html` for interactive API documentation.
+Swagger UI is available once the application is running at `http://localhost:8080/api/swagger-ui.html` for interactive API documentation.
 
 ### Web UI
 

--- a/src/main/java/com/example/library/config/SecurityConfig.java
+++ b/src/main/java/com/example/library/config/SecurityConfig.java
@@ -11,7 +11,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.http.HttpMethod;
 
 @Configuration
 public class SecurityConfig {
@@ -28,8 +27,8 @@ public class SecurityConfig {
                 .requestMatchers(
                         "/", "/index.html",
                         "/app.js", "/styles.css", "/theme.js",
-                        "/auth/register", "/auth/login", "/auth/session",
-                        "/swagger-ui.html", "/v3/api-docs/**", "/swagger-ui/**"
+                        "/api/auth/register", "/api/auth/login", "/api/auth/session",
+                        "/api/swagger-ui.html", "/api/v3/api-docs/**", "/api/swagger-ui/**"
                 ).permitAll()
                 .anyRequest().authenticated()
             )


### PR DESCRIPTION
## Summary
- correct SecurityConfig paths to include `/api` prefix
- remove unused import and update Swagger URL in README

## Testing
- `mvnw test` *(fails: Failed to fetch apache-maven)*

------
https://chatgpt.com/codex/tasks/task_e_685d9d5592b8832fbf88912c868d9bba