### PR TITLE
Fix registration 403 by aligning security matchers

### DIFF
--- a/src/main/java/com/example/library/config/SecurityConfig.java
+++ b/src/main/java/com/example/library/config/SecurityConfig.java
@@ -27,8 +27,8 @@ public class SecurityConfig {
                 .requestMatchers(
                         "/", "/index.html",
                         "/app.js", "/styles.css", "/theme.js",
-                        "/api/auth/register", "/api/auth/login", "/api/auth/session",
-                        "/api/swagger-ui.html", "/api/v3/api-docs/**", "/api/swagger-ui/**"
+                        "/auth/register", "/auth/login", "/auth/session",
+                        "/swagger-ui.html", "/v3/api-docs/**", "/swagger-ui/**"
                 ).permitAll()
                 .anyRequest().authenticated()
             )


### PR DESCRIPTION
## Summary
- allow unauthenticated access to `/auth/*` and swagger endpoints when `spring.mvc.servlet.path` is `/api`

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/...)*

------
https://chatgpt.com/codex/tasks/task_e_685db1df158c832f8d9f7c9c9c3b86c0